### PR TITLE
Change `WC_Admin_Loader` reference to new namespaced class name

### DIFF
--- a/classes/ActionScheduler_Admin.php
+++ b/classes/ActionScheduler_Admin.php
@@ -80,7 +80,7 @@ class ActionScheduler_Admin {
 	 * Enqueue the scripts.
 	 */
 	function enqueue_scripts() {
-		if ( is_callable( [ 'WC_Admin_Loader',  'is_admin_page' ] ) && WC_Admin_Loader::is_admin_page() ) {
+		if ( is_callable( [ 'Automattic\WooCommerce\Admin\Loader',  'is_admin_page' ] ) && Automattic\WooCommerce\Admin\Loader::is_admin_page() ) {
 			wp_enqueue_script( 'scheduled-actions-admin' );
 			wp_enqueue_script( WC_ADMIN_APP );
 		}


### PR DESCRIPTION
This PR changes a reference that was using the (now defunct) `WC_Admin` prefix to use the namespaced class instead. This was preventing the main script from being enqueued.

@rrennick: Not sure if this repo is still worth updating but since it is publicly available and could be used for inspiration on how to write extensions for WCA, I was thinking it should at least run against the latest WCA. What do you think?