### PR TITLE
add default per_page parameter value

### DIFF
--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -50,7 +50,7 @@ class ActionsReport extends Component {
 			if ( query.status !== prevQuery.status ) {
 				query.orderby = 'scheduled';
 				query.order = 'asc';
-				query.per_page = prevQuery.per_page;
+				query.per_page = prevQuery.per_page ? prevQuery.per_page : 100;
 			}
 			this.fetchActionData( query );
 		}
@@ -215,7 +215,7 @@ class ActionsReport extends Component {
 
 	renderPlaceholder() {
 		const headers = this.getHeadersContent();
-		return ( 
+		return (
 			<Card
 				title={ __( 'Scheduled Actions', 'action-scheduler-admin' ) }
 				className="action-scheduler-admin-placeholder"

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -19,7 +19,12 @@ import Currency from '@woocommerce/currency';
  * Internal dependencies
  */
 import { statusFilters } from './config';
+
+/**
+ * Set defaults
+ */
 const showDatePicker = false;
+const DEFAULT_PER_PAGE = 100;
 
 //@todo: import './style.scss'; if necessary
 
@@ -50,7 +55,7 @@ class ActionsReport extends Component {
 			if ( query.status !== prevQuery.status ) {
 				query.orderby = 'scheduled';
 				query.order = 'asc';
-				query.per_page = prevQuery.per_page ? prevQuery.per_page : 100;
+				query.per_page = prevQuery.per_page ? prevQuery.per_page : DEFAULT_PER_PAGE;
 			}
 			this.fetchActionData( query );
 		}


### PR DESCRIPTION
Closes #16 

This PR adds a default of 100 rows per page to the query object.

### Testing

1 - Use this snippet to create a few hundred action if needed
```
add_action( 'init', function() {
    for ( $i = 1; $i < 200; $i++ )
        as_enqueue_async_action( 'as-async-test' . $i );
} );
```
2. run `npm run watch`
3. Go to Analytics -> Scheduled Actions
4. Verify the status filter, per page, and page number controls work correctly.
