### PR TITLE
add schedule zero date display for async actions

### DIFF
--- a/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
+++ b/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
@@ -285,6 +285,9 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WC_REST_CRUD_Control
 		];
 
 		if ( ! $schedule->next() ) {
+			if ( is_a( $schedule, 'ActionScheduler_NullSchedule' ) ) {
+				$schedule_display['date'] = '0000-00-00 00:00:00';
+			}
 			return $schedule_display;
 		}
 

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -158,7 +158,7 @@ class ActionsReport extends Component {
 				{
 					display: (
 						<Fragment>
-						{ scheduled ? <Date date={ scheduled } screenReaderFormat="F j, Y H:i:s" visibleFormat="Y-m-d H:i:s P" /> : scheduled }<br />
+						{ scheduled > '0000-00-00 00:00:00' ? <Date date={ scheduled } screenReaderFormat="F j, Y H:i:s" visibleFormat="Y-m-d H:i:s P" /> : scheduled }<br />
 						{ schedule_delta }
 						</Fragment>
 					),


### PR DESCRIPTION
Closes #28 

This PR adds `0000-00-00 00:00:00` as the schedule display value for async actions. 

### Testing

1 - Use this snippet to create a few hundred action if needed
```
add_action( 'init', function() {
    for ( $i = 1; $i < 200; $i++ )
        as_enqueue_async_action( 'as-async-test' . $i );
} );
```
2. run `npm run watch`
3. Go to Analytics -> Scheduled Actions
4. The actions created with the snippet should show `0000-00-00 00:00:00` as the schedule date.