### PR TITLE
fix warnings and add summary row

### DIFF
--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Card } from '@wordpress/components';
+import { Card, CardFooter } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -12,7 +12,7 @@ import { map } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { Date, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { Date, ReportFilters, TableCard, TablePlaceholder, TableSummary } from '@woocommerce/components';
 import { getQuery, onQueryChange } from '@woocommerce/navigation';
 import Currency from '@woocommerce/currency';
 
@@ -132,7 +132,7 @@ class ActionsReport extends Component {
 	}
 
 	getSummary() {
-		const { totals } = this.state;
+		const { totals = {} } = this.state;
 		const {
 			complete = 0,
 			pending = 0,
@@ -262,6 +262,9 @@ class ActionsReport extends Component {
 				className="action-scheduler-admin-placeholder"
 			>
 				<TablePlaceholder caption={ __( 'Scheduled Actions', 'action-scheduler-admin' ) } headers={ headers } />
+				<CardFooter justify="center">
+					<TableSummary data={ this.getSummary() } />
+				</CardFooter>
 			</Card>
 		);
 	}

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -38,6 +38,7 @@ class ActionsReport extends Component {
 		};
 		this.getHeadersContent = this.getHeadersContent.bind( this );
 		this.getRowsContent = this.getRowsContent.bind( this );
+		this.getSummary = this.getSummary.bind( this );
 	}
 
 	componentDidMount() {
@@ -80,6 +81,7 @@ class ActionsReport extends Component {
 			this.setState( {
 				actions: response.actions,
 				pagination: response.pagination,
+				totals: response.totals,
 				loading: false,
 			} );
 		} );
@@ -124,6 +126,39 @@ class ActionsReport extends Component {
 				key: 'recurrence',
 				required: false,
 				isSortable: true,
+			},
+		];
+	}
+
+	getSummary() {
+		const { totals } = this.state;
+		const {
+			complete = 0,
+			pending = 0,
+			inProgess = 0,
+			canceled = 0,
+			failed = 0,
+		} = totals;
+		return [
+			{
+				label: __('complete', 'action-scheduler-admin' ),
+				value: complete,
+			},
+			{
+				label: __('pending', 'action-scheduler-admin' ),
+				value: pending,
+			},
+			{
+				label: __('in-progress', 'action-scheduler-admin' ),
+				value: inProgess,
+			},
+			{
+				label: __('canceled', 'action-scheduler-admin' ),
+				value: canceled,
+			},
+			{
+				label: __('failed', 'action-scheduler-admin' ),
+				value: failed,
 			},
 		];
 	}
@@ -231,7 +266,7 @@ class ActionsReport extends Component {
 	}
 
 	renderTable() {
-		const { path, query } = this.props;
+		const { query } = this.props;
 		const { perPage, totalRows } = this.state.pagination;
 
 		const rows = this.getRowsContent() || [];
@@ -247,7 +282,7 @@ class ActionsReport extends Component {
 				headers={ headers }
 				onQueryChange={ onQueryChange }
 				query={ query }
-				summary={ null }
+				summary={ this.getSummary() }
 			/>
 		);
 	}
@@ -256,28 +291,6 @@ class ActionsReport extends Component {
 		const { loading, actions } = this.state;
 		const { path, query } = this.props;
 		const currency = new Currency();
-
-		// if we aren't loading, and there are no labels
-		// show an EmptyContent message
-		if ( ! loading && ! actions.length ) {
-			return (
-				<Fragment>
-					<ReportFilters
-						currency={ currency }
-						filters={ statusFilters }
-						path={ path }
-						query={ query }
-						showDatePicker={ showDatePicker }
-					/>
-					<EmptyContent
-						title={ __( 'No results were found.', 'action-scheduler-admin' ) }
-						message={ __( 'Choose a different Action Status.', 'action-scheduler-admin' ) }
-						actionLabel=""
-						actionURL="#"
-					/>
-				</Fragment>
-			);
-		}
 
 		return (
 			<Fragment>

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -94,24 +94,28 @@ class ActionsReport extends Component {
 				label: __( 'Hook', 'action-scheduler-admin' ),
 				key: 'hook',
 				required: true,
+				isLeftAligned: true,
 				isSortable: true,
 			},
 			{
 				label: __( 'Status', 'action-scheduler-admin' ),
 				key: 'status',
 				required: false,
+				isLeftAligned: true,
 				isSortable: false,
 			},
 			{
 				label: __( 'Group', 'action-scheduler-admin' ),
 				key: 'group',
 				required: false,
+				isLeftAligned: true,
 				isSortable: true,
 			},
 			{
 				label: __( 'Arguments', 'action-scheduler-admin' ),
 				key: 'parameters',
 				required: false,
+				isLeftAligned: true,
 				isSortable: false,
 			},
 			{
@@ -120,12 +124,14 @@ class ActionsReport extends Component {
 				required: true,
 				defaultSort: true,
 				defaultOrder: 'asc',
+				isLeftAligned: true,
 				isSortable: true,
 			},
 			{
 				label: __( 'Recurrence', 'action-scheduler-admin' ),
 				key: 'recurrence',
 				required: false,
+				isLeftAligned: true,
 				isSortable: true,
 			},
 		];

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { Card } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -11,7 +12,7 @@ import { map } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { Card, Date, EmptyContent, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { Date, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
 import { getQuery, onQueryChange } from '@woocommerce/navigation';
 import Currency from '@woocommerce/currency';
 
@@ -288,7 +289,7 @@ class ActionsReport extends Component {
 	}
 
 	render() {
-		const { loading, actions } = this.state;
+		const { loading } = this.state;
 		const { path, query } = this.props;
 		const currency = new Currency();
 


### PR DESCRIPTION
This PR fixes:

- deprecated warning for the missing REST API  permission callback
- deprecated warning for the `<Card>` component
- adds the summary row at the bottom of the table
- Left aligns the columns

### Testing

1 - Use this snippet to create a few hundred action if needed
```
add_action( 'init', function() {
    for ( $i = 1; $i < 200; $i++ )
        as_enqueue_async_action( 'as-async-test' . $i );
} );
```
2. run `npm run watch`
3. Go to WooCommerce -> Scheduled Actions
4. Change the status drop down to `All`
5. A list of actions should load
6. Check that the PHP debug log doesn't have `PHP Notice:  register_rest_route was called <strong>incorrectly</strong>.`
7. Check that the browser console doesn't have the `deprecated <Card>` warning
8. Scroll to the bottom and compare the totals to the number of actions shown in the pagination block