### PR TITLE
Add run and cancel functionality

### DIFF
--- a/classes/ActionScheduler_Admin.php
+++ b/classes/ActionScheduler_Admin.php
@@ -82,6 +82,7 @@ class ActionScheduler_Admin {
 	function enqueue_scripts() {
 		if ( is_callable( [ 'Automattic\WooCommerce\Admin\Loader',  'is_admin_page' ] ) && Automattic\WooCommerce\Admin\Loader::is_admin_page() ) {
 			wp_enqueue_script( 'scheduled-actions-admin' );
+			wp_enqueue_style( WC_ADMIN_APP );
 			wp_enqueue_script( WC_ADMIN_APP );
 		}
 	}

--- a/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
+++ b/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
@@ -279,21 +279,24 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WP_REST_Controller {
 	public function run_action( $request ) {
 		$store  = ActionScheduler::store();
 		$runner = ActionScheduler::runner();
-		if ( ! empty( $request['id'] ) ) {
-			try {
-				$runner->process_action( $request['id'], 'REST API' );
-				$response = [ 'message' => 'Success' ];
-			} catch ( Exception $e ) {
-				$response = [ 'message' => $e->getMessage() ];
-			}
-			$status = $store->get_status( $request['id'] );
-			$response['status'] = $this->get_status_display( $status );
-		} else {
+
+		if ( empty( $request['id'] ) ) {
 			$response = [
 				'message' => 'Not found',
 				'status' => ''
 			];
+			return rest_ensure_response( $response );
 		}
+
+		try {
+			$runner->process_action( $request['id'], 'REST API' );
+			$response = [ 'message' => 'Success' ];
+		} catch ( Exception $e ) {
+			$response = [ 'message' => $e->getMessage() ];
+		}
+		$status = $store->get_status( $request['id'] );
+		$response['status'] = $this->get_status_display( $status );
+
 		return rest_ensure_response( $response );
 	}
 
@@ -311,7 +314,7 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WP_REST_Controller {
 				'message' => 'Not found',
 				'status' => ''
 			];
-			return rest_ensure_response( $response )
+			return rest_ensure_response( $response );
 		}
 
 		try {
@@ -366,6 +369,12 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WP_REST_Controller {
 		return $output;
 	}
 
+	/**
+	 * Lookup a status title using a status code.
+	 *
+	 * @param $status Status code.
+	 * @return string
+	 */
 	protected function get_status_display( $status ) {
 		$store         = ActionScheduler::store();
 		$status_labels = $store->get_status_labels();

--- a/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
+++ b/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
@@ -306,25 +306,26 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WP_REST_Controller {
 	public function cancel_action( $request ) {
 		$store = ActionScheduler::store();
 
-		if ( ! empty( $request['id'] ) ) {
-			try {
-				if ( ActionScheduler::store()->get_status( $request['id'] ) !== ActionScheduler_Store::STATUS_PENDING ) {
-					$response = [ 'message' => 'Action was not canceled' ];
-				} else {
-					ActionScheduler::store()->cancel_action( $request['id'] );
-					$response = [ 'message' => 'Success' ];
-				}
-			} catch ( Exception $e ) {
-				$response = [ 'message' => $e->getMessage() ];
-			}
-			$status = $store->get_status( $request['id'] );
-			$response['status'] = $this->get_status_display( $status );
-		} else {
+		if ( empty( $request['id'] ) ) {
 			$response = [
 				'message' => 'Not found',
 				'status' => ''
 			];
+			return rest_ensure_response( $response )
 		}
+
+		try {
+			if ( ActionScheduler::store()->get_status( $request['id'] ) !== ActionScheduler_Store::STATUS_PENDING ) {
+				$response = [ 'message' => 'Action was not canceled' ];
+			} else {
+				ActionScheduler::store()->cancel_action( $request['id'] );
+				$response = [ 'message' => 'Success' ];
+			}
+		} catch ( Exception $e ) {
+			$response = [ 'message' => $e->getMessage() ];
+		}
+		$status = $store->get_status( $request['id'] );
+		$response['status'] = $this->get_status_display( $status );
 		return rest_ensure_response( $response );
 	}
 	/**

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { Button, Card, CheckboxControl } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -11,7 +12,7 @@ import { map } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { Card, Date, EmptyContent, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { Date, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
 import { getQuery, onQueryChange } from '@woocommerce/navigation';
 import Currency from '@woocommerce/currency';
 
@@ -23,6 +24,7 @@ import { statusFilters } from './config';
 /**
  * Set defaults
  */
+const actionsEndpoint = `asa/v1/actions`;
 const showDatePicker = false;
 const DEFAULT_PER_PAGE = 100;
 
@@ -35,9 +37,22 @@ class ActionsReport extends Component {
 		this.state = {
 			actions: null,
 			loading: true,
+			isBusy: true,
 		};
 		this.getHeadersContent = this.getHeadersContent.bind( this );
 		this.getRowsContent = this.getRowsContent.bind( this );
+		this.getCheckbox = this.getCheckbox.bind( this );
+		this.getAllCheckbox = this.getAllCheckbox.bind( this );
+		this.onCancel = this.onCancel.bind( this );
+		this.onRun = this.onRun.bind( this );
+		this.processAction = this.processAction.bind( this );
+		this.selectedIndex = this.selectedIndex.bind( this );
+		this.selectedAll = this.selectedAll.bind( this );
+		this.selectRow = this.selectRow.bind( this );
+		this.selectAllRows = this.selectAllRows.bind( this );
+		this.setBusy = this.setBusy.bind( this );
+		this.unsetBusy = this.unsetBusy.bind( this );
+		this.updateActionStatus = this.updateActionStatus.bind( this );
 	}
 
 	componentDidMount() {
@@ -62,8 +77,6 @@ class ActionsReport extends Component {
 	}
 
 	fetchActionData( query ) {
-		const actionsEndpoint = `asa/v1/actions`;
-
 		var fullQuery = Object.assign( {
 				orderby: 'scheduled',
 				order: 'asc',
@@ -76,17 +89,167 @@ class ActionsReport extends Component {
 			fullQuery.status = '';
 		}
 
+		if ( ! this.setBusy() ) {
+			return;
+		}
+
 		apiFetch( { path: addQueryArgs( actionsEndpoint, fullQuery ) } ).then( response => {
+			var enabledRows = map( response.actions, action => {
+				if ( action.status == 'Pending' ) {
+					return action.id;
+				} else {
+					return null;
+				}
+			} ).filter( id => id != null );
 			this.setState( {
+				enabledRows,
+				selectedRows: [],
 				actions: response.actions,
 				pagination: response.pagination,
 				loading: false,
 			} );
 		} );
+		this.unsetBusy();
+	}
+
+	setBusy() {
+		const { isBusy } = this.state;
+		if ( isBusy ) {
+			return false;
+		}
+		this.setState( {
+			isBusy: true,
+		} );
+		return true;
+	}
+
+	unsetBusy() {
+		this.setState( {
+			isBusy: false,
+		} );
+	}
+
+	processAction( actionId, action ) {
+		this.updateActionStatus( actionId, 'Complete' );
+	}
+
+	updateActionStatus( actionId, status ) {
+		const { actions } = this.state;
+
+		const updatedActions = map( actions, action => {
+			if ( action.id == actionId ) {
+				action.status = status;
+			}
+			return action;
+		} );
+		this.setState( {
+			actions: updatedActions,
+		} );
+	}
+	onRun() {
+		const { selectedRows } = this.state;
+		const actionIds = [ ...selectedRows ];
+		let actionId;
+
+		if ( this.setBusy() ) {
+			while ( actionIds.length > 0 ) {
+				actionId = actionIds.shift();
+				this.processAction( actionId, 'run' );
+				this.setState( {
+					selectedRows: actionIds,
+				} );
+			}
+		}
+		this.unsetBusy();
+	}
+
+	onCancel() {
+		this.setBusy();
+		//
+		this.unsetBusy();
+	}
+
+	selectedIndex( i ) {
+		const { selectedRows } = this.state;
+		if ( ! selectedRows ) {
+			return false;
+		}
+
+		return selectedRows.findIndex( ( id ) => id == i );
+	}
+
+	selectedAll() {
+		const { enabledRows, selectedRows } = this.state;
+		if ( ! enabledRows || ! selectedRows ) {
+			return false;
+		}
+		return enabledRows.length > 0 && selectedRows.length == enabledRows.length;
+	}
+
+	selectRow( i ) {
+		const { selectedRows } = this.state;
+		const found = this.selectedIndex( i );
+		let newRows = [];
+
+		if ( found >= 0 ) {
+			newRows = [
+				...selectedRows.slice( 0, found ),
+				...selectedRows.slice( found + 1 ),
+			];
+		} else {
+			newRows = [
+				...selectedRows,
+				i,
+			];
+		}
+		newRows.sort();
+
+		this.setState( {
+			selectedRows: newRows,
+		} );
+	}
+
+	selectAllRows() {
+		const { enabledRows } = this.state;
+		let newRows = this.selectedAll() ? [] : [ ...enabledRows ];
+		this.setState( {
+			selectedRows: newRows,
+		} );
+	}
+
+	getCheckbox( i, enabled ) {
+		const isChecked = this.selectedIndex( i ) >= 0;
+		return {
+			display: (
+				<CheckboxControl
+					onChange={ () => this.selectRow( i ) }
+					disabled={ ! enabled }
+					checked={ isChecked }
+				/>
+			),
+			value: false,
+		};
+	}
+
+	getAllCheckbox() {
+		return {
+			cellClassName: 'is-checkbox-column',
+			key: 'compare',
+			label: (
+				<CheckboxControl
+					onChange={ this.selectAllRows }
+					aria-label={ __( 'Select All' ) }
+					checked={ this.selectedAll() }
+				/>
+			),
+			required: true,
+		};
+
 	}
 
 	getHeadersContent() {
 		return [
+			this.getAllCheckbox(),
 			{
 				label: __( 'Hook', 'action-scheduler-admin' ),
 				key: 'hook',
@@ -133,6 +296,7 @@ class ActionsReport extends Component {
 
 		return map( actions, row => {
 			const {
+				id,
 				hook,
 				group,
 				status,
@@ -143,7 +307,9 @@ class ActionsReport extends Component {
 				recurrence,
 			} = row;
 			const scheduledIsDate = scheduled && Number.isInteger( scheduled.substr( 0, 4 ) );
+			const isPending = status == 'Pending';
 			return [
+				this.getCheckbox( id, isPending ),
 				{
 					display: this.renderHook( hook ),
 					value: hook,
@@ -231,15 +397,38 @@ class ActionsReport extends Component {
 	}
 
 	renderTable() {
-		const { path, query } = this.props;
+		const { query } = this.props;
 		const { perPage, totalRows } = this.state.pagination;
+		const { isBusy, selectedRows } = this.state;
 
 		const rows = this.getRowsContent() || [];
-
+		const buttonsEnabled = ! isBusy && selectedRows && selectedRows.length;
 		const headers = this.getHeadersContent();
 
 		return (
 			<TableCard
+				actions ={ [
+					(
+						<Button
+							key={ 'run' }
+							className={ 'is-primary' }
+							text={ __( 'Run Selected', 'action-scheduler-admin' ) }
+							onClick={ this.onRun }
+							disabled={ ! buttonsEnabled }
+							variant={ 'primary' }
+						/>
+					),
+					(
+						<Button
+							key={ 'cancel' }
+							className={ 'is-secondary' }
+							text={ __( 'Cancel Selected', 'action-scheduler-admin' ) }
+							onClick={ this.onCancel }
+							disabled={ ! buttonsEnabled }
+							variant={ 'secondary' }
+						/>
+					),
+				] }
 				title={ __( 'Scheduled Actions', 'action-scheduler-admin' ) }
 				rows={ rows }
 				totalRows={ totalRows }
@@ -256,28 +445,6 @@ class ActionsReport extends Component {
 		const { loading, actions } = this.state;
 		const { path, query } = this.props;
 		const currency = new Currency();
-
-		// if we aren't loading, and there are no labels
-		// show an EmptyContent message
-		if ( ! loading && ! actions.length ) {
-			return (
-				<Fragment>
-					<ReportFilters
-						currency={ currency }
-						filters={ statusFilters }
-						path={ path }
-						query={ query }
-						showDatePicker={ showDatePicker }
-					/>
-					<EmptyContent
-						title={ __( 'No results were found.', 'action-scheduler-admin' ) }
-						message={ __( 'Choose a different Action Status.', 'action-scheduler-admin' ) }
-						actionLabel=""
-						actionURL="#"
-					/>
-				</Fragment>
-			);
-		}
 
 		return (
 			<Fragment>


### PR DESCRIPTION
This PR adds run and cancel functionality via row checkboxes and table action buttons. It also updates the REST controller so that the controller is not dependent on WooCommerce being active.

### Testing

1 - Use this snippet to create a few hundred action if needed
```
add_action( 'init', function() {
    for ( $i = 1; $i < 200; $i++ )
        as_schedule_single_action( time() + DAY_IN_SECONDS, 'as-single-test' . $i );
} );
```
2. run `npm run watch`
3. Go to WooCommerce -> Scheduled Actions
4. A list of pending actions should load
5. Verify the `Select All` checkbox toggles whether all the actions are checked
6. Select a few actions
7. Click `Cancel Selected`
8. Verify those actions are unchecked and the status is updated to Canceled
9. Repeat 6-8 with `Run Selected`
10. Change the status drop down to `All`
11. Verify that only `Pending` actions can be selected