### PR TITLE
add build zip archive script

### DIFF
--- a/bin/build-zip.sh
+++ b/bin/build-zip.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Build the plugin zip
+
+ZIP_NAME='action-scheduler-admin.zip'
+SAVE_PATH=$(pwd)
+
+# Switch to the root of the repository
+cd $(dirname $(dirname $0))
+
+# Remove existing archive
+if [ -f $ZIP_NAME ]; then
+  rm $ZIP_NAME
+fi
+
+# Build and zip
+npm run build
+zip -r action-scheduler-admin.zip ./ -x \
+  ./\*.config.js \
+  ./js\* \
+  ./package\*.json \
+  ./bin/\* \
+  ./node_modules/\* \
+  ./.git/\* \
+  ./.\*
+
+# Restore environment
+cd $SAVE_PATH

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "rimraf ./dist",
     "prebuild": "npm run -s install-if-deps-outdated",
     "build": "npm run clean && npm run -s i18n && cross-env NODE_ENV=production webpack",
+    "build:zip": "bin/build-zip.sh",
     "start": "webpack --watch",
     "i18n:js": "cross-env NODE_ENV=production babel js -o /dev/null",
     "i18n:pot": "wp --allow-root i18n make-pot . languages/action-scheduler-admin.pot --include=\"js,includes\" --exclude=\"dist,node_modules\" --slug=action-scheduler-admin",


### PR DESCRIPTION
This PR adds a script to build a zip archive of the plugin.

### Testing instructions

- Use this snippet to create test pending actions in a test install
```
add_action( 'init', function() {
	$prefix = [ 'one', 'two', 'three', 'four', 'five' ];
    for ( $i = 1; $i <= 20; $i++ ) {
		$hook = $prefix[ $i % 5 ] . '-single-test-' . $i;
        as_schedule_single_action( time() + DAY_IN_SECONDS, $hook );
	}
} );
```
- In this repo run `npm run build:zip`
- Install the generated `action-scheduler-admin.zip` in the test install
- Go to WooCommerce -> Scheduled Actions
- Type 'one', 'two', 'three', 'four', or 'five' in the search box
- Click the search icon
- Verify all rows in the table match the search string
- Verify report paging, filtering, and ordering functions work correctly while maintaining the search filter
- Clear the search box
- Verify the table rows return to show all rows matching the status filter
- Test that pending actions can be both run and cancelled